### PR TITLE
feat(middleware): add cache no-store on fetch calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vercel Edge Middleware for redirection.io
 
-This package allow to use redirection.io within
+This package allows to use redirection.io within
 a [Vercel Edge Middleware](https://vercel.com/docs/functions/edge-middleware).
 
 Look at our documentation about our Vercel Edge Middleware integration
@@ -83,4 +83,13 @@ const middleware = createRedirectionIoMiddleware({
 });
 
 export default middleware;
+```
+
+
+### Development
+
+Build
+
+```bash
+yarn run tsc
 ```

--- a/middleware.js
+++ b/middleware.js
@@ -3,7 +3,7 @@ import { ipAddress } from '@vercel/functions';
 import * as redirectionio from '@redirection.io/redirectionio';
 const REDIRECTIONIO_TOKEN = process.env.REDIRECTIONIO_TOKEN || '';
 const REDIRECTIONIO_INSTANCE_NAME = process.env.REDIRECTIONIO_INSTANCE_NAME || 'redirection-io-vercel-middleware';
-const REDIRECTIONIO_VERSION = 'redirection-io-vercel-middleware/0.3.5';
+const REDIRECTIONIO_VERSION = 'redirection-io-vercel-middleware/0.3.9';
 const REDIRECTIONIO_ADD_HEADER_RULE_IDS = process.env.REDIRECTIONIO_ADD_HEADER_RULE_IDS ? process.env.REDIRECTIONIO_ADD_HEADER_RULE_IDS === 'true' : false;
 const REDIRECTIONIO_TIMEOUT = process.env.REDIRECTIONIO_TIMEOUT ? parseInt(process.env.REDIRECTIONIO_TIMEOUT, 10) : 500;
 export const createRedirectionIoMiddleware = (config) => {
@@ -39,6 +39,7 @@ export const createRedirectionIoMiddleware = (config) => {
             }
             const fetchResponse = await fetch(request, {
                 redirect: 'manual',
+                cache: 'no-store',
             });
             const backendResponse = new Response(fetchResponse.body, fetchResponse);
             if (response) {
@@ -181,6 +182,7 @@ async function fetchRedirectionIOAction(redirectionIORequest) {
                     'User-Agent': 'vercel-edge-middleware/' + REDIRECTIONIO_VERSION,
                     'x-redirectionio-instance-name': REDIRECTIONIO_INSTANCE_NAME,
                 },
+                cache: 'no-store',
             }),
             new Promise((_, reject) => setTimeout(() => reject(new Error('Timeout')), REDIRECTIONIO_TIMEOUT)),
         ]);
@@ -301,6 +303,7 @@ async function log(response, backendStatusCode, redirectionioRequest, startTimes
                 'User-Agent': 'vercel-edge-middleware/' + REDIRECTIONIO_VERSION,
                 'x-redirectionio-instance-name': REDIRECTIONIO_INSTANCE_NAME,
             },
+            cache: 'no-store',
         });
     }
     catch (err) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,11 +1,11 @@
-import {next, RequestContext} from "@vercel/edge";
-import {ipAddress} from '@vercel/functions';
+import { next, RequestContext } from "@vercel/edge";
+import { ipAddress } from '@vercel/functions';
 import * as redirectionio from '@redirection.io/redirectionio';
-import type {NextRequest} from "next/server";
+import type { NextRequest } from "next/server";
 
 const REDIRECTIONIO_TOKEN = process.env.REDIRECTIONIO_TOKEN || '';
 const REDIRECTIONIO_INSTANCE_NAME = process.env.REDIRECTIONIO_INSTANCE_NAME || 'redirection-io-vercel-middleware';
-const REDIRECTIONIO_VERSION = 'redirection-io-vercel-middleware/0.3.5';
+const REDIRECTIONIO_VERSION = 'redirection-io-vercel-middleware/0.3.9';
 const REDIRECTIONIO_ADD_HEADER_RULE_IDS = process.env.REDIRECTIONIO_ADD_HEADER_RULE_IDS ? process.env.REDIRECTIONIO_ADD_HEADER_RULE_IDS === 'true' : false;
 const REDIRECTIONIO_TIMEOUT = process.env.REDIRECTIONIO_TIMEOUT ? parseInt(process.env.REDIRECTIONIO_TIMEOUT, 10) : 500;
 
@@ -62,6 +62,7 @@ export const createRedirectionIoMiddleware = (config: CreateMiddlewareConfig): M
 
             const fetchResponse = await fetch(request, {
                 redirect: 'manual',
+                cache: 'no-store',
             });
             const backendResponse = new Response(fetchResponse.body, fetchResponse);
 
@@ -244,6 +245,7 @@ async function fetchRedirectionIOAction(redirectionIORequest: redirectionio.Requ
                     'User-Agent': 'vercel-edge-middleware/' + REDIRECTIONIO_VERSION,
                     'x-redirectionio-instance-name': REDIRECTIONIO_INSTANCE_NAME,
                 },
+                cache: 'no-store',
             }),
             new Promise((_, reject) =>
                 setTimeout(() => reject(new Error('Timeout')), REDIRECTIONIO_TIMEOUT)
@@ -413,6 +415,7 @@ async function log(response: Response, backendStatusCode: number, redirectionioR
                     'User-Agent': 'vercel-edge-middleware/' + REDIRECTIONIO_VERSION,
                     'x-redirectionio-instance-name': REDIRECTIONIO_INSTANCE_NAME,
                 },
+                cache: 'no-store',
             }
         );
     } catch (err) {


### PR DESCRIPTION
Add `cache: 'no-store'` to fetch optopns