### PR TITLE
feat(middleware): add new matcher option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,32 +55,50 @@ const myExistingMiddleware = (request: Request) => {
 const middleware = createRedirectionIoMiddleware({
     previousMiddleware: myExistingMiddleware, // In this case your middleware is executed before redirection.io middleware
     nextMiddleware: myExistingMiddleware, // In this case your middleware is executed after redirection.io middleware
+    // Optional: matcher to specify which routes should be ignored by redirection.io middleware
+    // Default: "^/((?!api/|_next/|_static/|_vercel|[\\w-]+\\.\\w+).*)$"
+    matcherRegex: "^/((?!api/|_next/|_static/|_vercel|[\\w-]+\\.\\w+).*)$",
 });
 
 export default middleware;
 ```
+
+By default, our middleware ignores certain routes even if there's an exported configuration. The ignored routes are:
+
+-   `/api/*` routes
+-   `/next/*` (Next.js internals)
+-   `/static/*` (inside `/public`)
+-   all root files inside /public (e.g. /favicon.ico)
+
+If you want the middleware to handle all routes without any exclusions, you can set the `matcherRegex` option to `null`:
+
+```typescript
+createRedirectionIoMiddleware({ matcherRegex: null });
+```
+
+Here's a summary of the middleware options:
+
+| Option               | Type           | Description                                                                  |
+| -------------------- | -------------- | ---------------------------------------------------------------------------- |
+| `previousMiddleware` | Function       | Middleware to be executed before redirection.io middleware                   |
+| `nextMiddleware`     | Function       | Middleware to be executed after redirection.io middleware                    |
+| `matcherRegex`       | String or null | Regex to specify which routes should be handled by redirection.io middleware |
 
 ### Next.js
 
 If you are using next.js middlewares, you can use the `createRedirectionIoMiddleware` method
 from `@redirection.io/vercel-middleware/next` which is compatible with `NextRequest` type.
 
-```typescript
-import { createRedirectionIoMiddleware } from "@redirection.io/vercel-middleware/next";
-import { NextRequest } from "next/server";
+```diff
+- import { createRedirectionIoMiddleware } from "@redirection.io/vercel-middleware";
++ import { createRedirectionIoMiddleware } from "@redirection.io/vercel-middleware/next";
++ import { NextRequest } from "next/server";
 
-const myExistingMiddleware = (request: NextRequest) => {
-    // Your existing middleware logic
-
+- const myExistingMiddleware = (request: Request) => {
++ const myExistingMiddleware = (request: NextRequest) => {
     return next();
 };
 
-const middleware = createRedirectionIoMiddleware({
-    previousMiddleware: myExistingMiddleware, // In this case your middleware is executed before redirection.io middleware
-    nextMiddleware: myExistingMiddleware, // In this case your middleware is executed after redirection.io middleware
-});
-
-export default middleware;
 ```
 
 ### Development

--- a/middleware.js
+++ b/middleware.js
@@ -3,13 +3,24 @@ import { ipAddress } from "@vercel/functions";
 import * as redirectionio from "@redirection.io/redirectionio";
 const REDIRECTIONIO_TOKEN = process.env.REDIRECTIONIO_TOKEN || "";
 const REDIRECTIONIO_INSTANCE_NAME = process.env.REDIRECTIONIO_INSTANCE_NAME || "redirection-io-vercel-middleware";
-const REDIRECTIONIO_VERSION = "redirection-io-vercel-middleware/0.3.10";
+const REDIRECTIONIO_VERSION = "redirection-io-vercel-middleware/0.3.12";
 const REDIRECTIONIO_ADD_HEADER_RULE_IDS = process.env.REDIRECTIONIO_ADD_HEADER_RULE_IDS
     ? process.env.REDIRECTIONIO_ADD_HEADER_RULE_IDS === "true"
     : false;
 const REDIRECTIONIO_TIMEOUT = process.env.REDIRECTIONIO_TIMEOUT ? parseInt(process.env.REDIRECTIONIO_TIMEOUT, 10) : 500;
+const DEFAULT_CONFIG = {
+    matcherRegex: "^/((?!api/|_next/|_static/|_vercel|[\\w-]+\\.\\w+).*)$",
+};
 export const createRedirectionIoMiddleware = (config) => {
     return async (request, context) => {
+        const pathname = new URL(request.url).pathname;
+        config = {
+            ...DEFAULT_CONFIG,
+            ...config,
+        };
+        if (config.matcherRegex && !pathname.match(config.matcherRegex)) {
+            return next();
+        }
         // Avoid infinite loop
         if (
             request.headers.get("x-redirectionio-middleware") === "true" ||

--- a/middleware.ts
+++ b/middleware.ts
@@ -5,11 +5,15 @@ import type { NextRequest } from "next/server";
 
 const REDIRECTIONIO_TOKEN = process.env.REDIRECTIONIO_TOKEN || "";
 const REDIRECTIONIO_INSTANCE_NAME = process.env.REDIRECTIONIO_INSTANCE_NAME || "redirection-io-vercel-middleware";
-const REDIRECTIONIO_VERSION = "redirection-io-vercel-middleware/0.3.10";
+const REDIRECTIONIO_VERSION = "redirection-io-vercel-middleware/0.3.12";
 const REDIRECTIONIO_ADD_HEADER_RULE_IDS = process.env.REDIRECTIONIO_ADD_HEADER_RULE_IDS
     ? process.env.REDIRECTIONIO_ADD_HEADER_RULE_IDS === "true"
     : false;
 const REDIRECTIONIO_TIMEOUT = process.env.REDIRECTIONIO_TIMEOUT ? parseInt(process.env.REDIRECTIONIO_TIMEOUT, 10) : 500;
+
+const DEFAULT_CONFIG = {
+    matcherRegex: "^/((?!api/|_next/|_static/|_vercel|[\\w-]+\\.\\w+).*)$",
+};
 
 type Middleware = (request: Request | NextRequest, context: RequestContext) => Response | Promise<Response>;
 
@@ -18,10 +22,22 @@ type FetchResponse = (request: Request, useFetch: boolean) => Promise<Response>;
 type CreateMiddlewareConfig = {
     previousMiddleware?: Middleware;
     nextMiddleware?: Middleware;
+    matcherRegex?: string | null;
 };
 
 export const createRedirectionIoMiddleware = (config: CreateMiddlewareConfig): Middleware => {
     return async (request, context) => {
+        const pathname = new URL(request.url).pathname;
+
+        config = {
+            ...DEFAULT_CONFIG,
+            ...config,
+        };
+
+        if (config.matcherRegex && !pathname.match(config.matcherRegex)) {
+            return next();
+        }
+
         // Avoid infinite loop
         if (
             request.headers.get("x-redirectionio-middleware") === "true" ||

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@redirection.io/vercel-middleware",
-    "version": "0.3.11",
+    "version": "0.3.12",
     "description": "Vercel Edge Middleware for redirection.io",
     "main": "middleware.js",
     "license": "MIT",


### PR DESCRIPTION
Added `matcherRegex` configuration option to allow specifying routes that should be ignored by the redirection.io middleware

```diff
const middleware = createRedirectionIoMiddleware({
    previousMiddleware: myExistingMiddleware,
    nextMiddleware: myExistingMiddleware,
+   matcherRegex: "^/((?!api/auth).*)$", // Optional: matcher to specify which routes should be ignored by redirection.io middleware
});
```